### PR TITLE
[marron] #4 여행 일정 선택 페이지 구현

### DIFF
--- a/Front/package-lock.json
+++ b/Front/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vitest/coverage-v8": "^2.0.5",
+        "date-fns": "^4.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
@@ -5713,6 +5714,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/Front/package.json
+++ b/Front/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@vitest/coverage-v8": "^2.0.5",
+    "date-fns": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",

--- a/Front/src/components/calendar/Calendar.tsx
+++ b/Front/src/components/calendar/Calendar.tsx
@@ -34,8 +34,10 @@ const Calendar: React.FC<CalendarProps> = ({
   );
 
   useEffect(() => {
-    const currentMonth = calendarRef.current?.children[centerMonth];
-    currentMonth?.scrollIntoView({ behavior: "instant", block: "center" }); // 단번에 보이게, 수직 중앙에 위치
+    const currentMonth = calendarRef.current?.children[centerMonth] as HTMLElement;
+    if (currentMonth && typeof currentMonth.scrollIntoView === "function") { // test에서 currentMonth?.scrollIntoView is not a function 오류
+      currentMonth.scrollIntoView({ behavior: "instant", block: "center" });
+    }
   }, []);
 
   const isDateInRange = (date: Date) =>

--- a/Front/src/components/calendar/Calendar.tsx
+++ b/Front/src/components/calendar/Calendar.tsx
@@ -60,8 +60,8 @@ const Calendar: React.FC<CalendarProps> = ({
             ))}
           </S.WeekDays>
           <S.DaysGrid>
-            {[...Array(getDay(startOfMonth(month))).keys()].map((_, i) => (
-              <div key={i} />
+            {[...Array(getDay(startOfMonth(month))).keys()].map((num) => (
+              <div key={num} />
             ))}
             {eachDayOfInterval({
               start: startOfMonth(month),

--- a/Front/src/components/calendar/Calendar.tsx
+++ b/Front/src/components/calendar/Calendar.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from "react";
-import styled from "styled-components";
+import * as S from "../../styles/calendar.style";
 import {
   addMonths,
   subMonths,
@@ -19,6 +19,8 @@ interface CalendarProps {
 }
 
 const week = ["일", "월", "화", "수", "목", "금", "토"];
+const totalMonths = 13; // 13개월 달력 구성. 변경 가능성 있음
+const centerMonth = Math.floor(totalMonths / 2);
 
 const Calendar: React.FC<CalendarProps> = ({
   currentDate,
@@ -27,16 +29,16 @@ const Calendar: React.FC<CalendarProps> = ({
 }) => {
   const calendarRef = useRef<HTMLDivElement>(null);
 
-  const months = Array.from({ length: 13 }, (_, i) => addMonths(subMonths(currentDate, 6), i));
-  // 13개월 달 구성. 변경 가능성 있음
+  const months = Array.from({ length: totalMonths }, (_, i) =>
+    addMonths(subMonths(currentDate, 6), i)
+  );
 
   useEffect(() => {
-    const currentMonth = calendarRef.current?.children[Math.floor(months.length/2)];
+    const currentMonth = calendarRef.current?.children[centerMonth];
     currentMonth?.scrollIntoView({ behavior: "instant", block: "center" }); // 단번에 보이게, 수직 중앙에 위치
   }, []);
 
   const isDateInRange = (date: Date) =>
-    selectedDates.length === 2 &&
     isWithinInterval(date, {
       start: selectedDates[0],
       end: selectedDates[1],
@@ -46,16 +48,16 @@ const Calendar: React.FC<CalendarProps> = ({
   const isEndDate = (date: Date) => isSameDay(date, selectedDates[1]);
 
   return (
-    <Container ref={calendarRef}>
+    <S.Container ref={calendarRef}>
       {months.map((month) => (
-        <MonthContainer key={format(month, "yyyy-MM")}>
-          <MonthHeader>{format(month, "yyyy년 MM월")}</MonthHeader>
-          <WeekDays>
+        <S.MonthContainer key={format(month, "yyyy-MM")}>
+          <S.MonthHeader>{format(month, "yyyy년 MM월")}</S.MonthHeader>
+          <S.WeekDays>
             {week.map((day) => (
-              <WeekDay key={day}>{day}</WeekDay>
+              <S.WeekDay key={day}>{day}</S.WeekDay>
             ))}
-          </WeekDays>
-          <DaysGrid>
+          </S.WeekDays>
+          <S.DaysGrid>
             {[...Array(getDay(startOfMonth(month))).keys()].map((_, i) => (
               <div key={i} />
             ))}
@@ -63,7 +65,7 @@ const Calendar: React.FC<CalendarProps> = ({
               start: startOfMonth(month),
               end: endOfMonth(month),
             }).map((date) => (
-              <Day
+              <S.Day
                 key={format(date, "yy-MM-dd")}
                 onClick={() => onDateClick(date)}
                 $isInRange={isDateInRange(date)}
@@ -71,98 +73,13 @@ const Calendar: React.FC<CalendarProps> = ({
                 $isEndDate={isEndDate(date)}
               >
                 {format(date, "d")}
-              </Day>
+              </S.Day>
             ))}
-          </DaysGrid>
-        </MonthContainer>
+          </S.DaysGrid>
+        </S.MonthContainer>
       ))}
-    </Container>
+    </S.Container>
   );
 };
-
-const Container = styled.div`
-  height: 75vh;
-  overflow-y: auto;
-  background-color: #fcfcfc;
-  box-shadow: 0px 5px #fcfcfc;
-  padding: 20px;
-`;
-
-const MonthContainer = styled.div`
-  padding-bottom: 2rem;
-`;
-
-const MonthHeader = styled.h3`
-  text-align: center;
-  margin: 2rem 0;
-`;
-
-const WeekDays = styled.div`
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  text-align: center;
-  font-weight: bold;
-  height: 40px;
-`;
-
-const WeekDay = styled.div`
-  padding: 5px;
-`;
-
-const DaysGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-`;
-
-const Day = styled.div<{
-  $isInRange: boolean;
-  $isStartDate: boolean;
-  $isEndDate: boolean;
-}>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px;
-  width: 100%;
-  margin: 2px auto;
-  cursor: pointer;
-  position: relative;
-  z-index: 1;
-  color: ${({ $isStartDate, $isEndDate }) =>
-    $isStartDate || $isEndDate ? "white" : "black"};
-
-  &::before {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    height: 40px;
-    background-color: ${({ $isInRange }) => ($isInRange ? "#E7F0FF" : "unset")};
-    margin-left: ${({ $isStartDate }) => ($isStartDate ? "50%" : "unset")};
-    margin-right: ${({ $isEndDate }) => ($isEndDate ? "50%" : "unset")};
-    z-index: -1;
-    transform: translateY(-50%);
-  }
-
-  &::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: -1;
-    ${({ $isStartDate, $isEndDate }) =>
-      $isStartDate || $isEndDate
-        ? `
-        width: 40px;
-        height: 40px;
-        background-color: #4E94F8;
-        border-radius: 50%;`
-        : `
-        background-color: transparent;
-      `}
-  }
-`;
 
 export default Calendar;

--- a/Front/src/components/calendar/Calendar.tsx
+++ b/Front/src/components/calendar/Calendar.tsx
@@ -1,0 +1,168 @@
+import React, { useRef, useEffect } from "react";
+import styled from "styled-components";
+import {
+  addMonths,
+  subMonths,
+  startOfMonth,
+  endOfMonth,
+  eachDayOfInterval, // 시작일과 종료일 사이의 모든 날짜 배열 return
+  format,
+  isSameDay,
+  isWithinInterval,
+  getDay, // 날짜의 요일 return
+} from "date-fns";
+
+interface CalendarProps {
+  currentDate: Date;
+  selectedDates: Date[];
+  onDateClick: (date: Date) => void;
+}
+
+const week = ["일", "월", "화", "수", "목", "금", "토"];
+
+const Calendar: React.FC<CalendarProps> = ({
+  currentDate,
+  selectedDates,
+  onDateClick,
+}) => {
+  const calendarRef = useRef<HTMLDivElement>(null);
+
+  const months = Array.from({ length: 13 }, (_, i) => addMonths(subMonths(currentDate, 6), i));
+  // 13개월 달 구성. 변경 가능성 있음
+
+  useEffect(() => {
+    const currentMonth = calendarRef.current?.children[Math.floor(months.length/2)];
+    currentMonth?.scrollIntoView({ behavior: "instant", block: "center" }); // 단번에 보이게, 수직 중앙에 위치
+  }, []);
+
+  const isDateInRange = (date: Date) =>
+    selectedDates.length === 2 &&
+    isWithinInterval(date, {
+      start: selectedDates[0],
+      end: selectedDates[1],
+    });
+
+  const isStartDate = (date: Date) => isSameDay(date, selectedDates[0]);
+  const isEndDate = (date: Date) => isSameDay(date, selectedDates[1]);
+
+  return (
+    <Container ref={calendarRef}>
+      {months.map((month) => (
+        <MonthContainer key={format(month, "yyyy-MM")}>
+          <MonthHeader>{format(month, "yyyy년 MM월")}</MonthHeader>
+          <WeekDays>
+            {week.map((day) => (
+              <WeekDay key={day}>{day}</WeekDay>
+            ))}
+          </WeekDays>
+          <DaysGrid>
+            {[...Array(getDay(startOfMonth(month))).keys()].map((_, i) => (
+              <div key={i} />
+            ))}
+            {eachDayOfInterval({
+              start: startOfMonth(month),
+              end: endOfMonth(month),
+            }).map((date) => (
+              <Day
+                key={format(date, "yy-MM-dd")}
+                onClick={() => onDateClick(date)}
+                $isInRange={isDateInRange(date)}
+                $isStartDate={isStartDate(date)}
+                $isEndDate={isEndDate(date)}
+              >
+                {format(date, "d")}
+              </Day>
+            ))}
+          </DaysGrid>
+        </MonthContainer>
+      ))}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  height: 75vh;
+  overflow-y: auto;
+  background-color: #fcfcfc;
+  box-shadow: 0px 5px #fcfcfc;
+  padding: 20px;
+`;
+
+const MonthContainer = styled.div`
+  padding-bottom: 2rem;
+`;
+
+const MonthHeader = styled.h3`
+  text-align: center;
+  margin: 2rem 0;
+`;
+
+const WeekDays = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  font-weight: bold;
+  height: 40px;
+`;
+
+const WeekDay = styled.div`
+  padding: 5px;
+`;
+
+const DaysGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+`;
+
+const Day = styled.div<{
+  $isInRange: boolean;
+  $isStartDate: boolean;
+  $isEndDate: boolean;
+}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 40px;
+  width: 100%;
+  margin: 2px auto;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  color: ${({ $isStartDate, $isEndDate }) =>
+    $isStartDate || $isEndDate ? "white" : "black"};
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background-color: ${({ $isInRange }) => ($isInRange ? "#E7F0FF" : "unset")};
+    margin-left: ${({ $isStartDate }) => ($isStartDate ? "50%" : "unset")};
+    margin-right: ${({ $isEndDate }) => ($isEndDate ? "50%" : "unset")};
+    z-index: -1;
+    transform: translateY(-50%);
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: -1;
+    ${({ $isStartDate, $isEndDate }) =>
+      $isStartDate || $isEndDate
+        ? `
+        width: 40px;
+        height: 40px;
+        background-color: #4E94F8;
+        border-radius: 50%;`
+        : `
+        background-color: transparent;
+      `}
+  }
+`;
+
+export default Calendar;

--- a/Front/src/components/calendar/Calendar.tsx
+++ b/Front/src/components/calendar/Calendar.tsx
@@ -49,6 +49,11 @@ const Calendar: React.FC<CalendarProps> = ({
   const isStartDate = (date: Date) => isSameDay(date, selectedDates[0]);
   const isEndDate = (date: Date) => isSameDay(date, selectedDates[1]);
 
+  const isWeekend = (date: Date) => {
+    const dayOfWeek = getDay(date);
+    return dayOfWeek === 0 || dayOfWeek === 6;
+  };
+
   return (
     <S.Container ref={calendarRef}>
       {months.map((month) => (
@@ -73,6 +78,7 @@ const Calendar: React.FC<CalendarProps> = ({
                 $isInRange={isDateInRange(date)}
                 $isStartDate={isStartDate(date)}
                 $isEndDate={isEndDate(date)}
+                $isWeekend={isWeekend(date)}
               >
                 {format(date, "d")}
               </S.Day>

--- a/Front/src/pages/Cities.tsx
+++ b/Front/src/pages/Cities.tsx
@@ -24,7 +24,7 @@ const Cities: React.FC = () => {
   const handleSelectCities = () => {
     const selectedCityIds = selectedCities.map((city) => city.id);
     localStorage.setItem("selectedCityIds", JSON.stringify(selectedCityIds));
-    navigate("/calendar");
+    navigate("/dates");
   };
 
   const handleSelectCity = (city: City) => {

--- a/Front/src/pages/Dates.tsx
+++ b/Front/src/pages/Dates.tsx
@@ -4,8 +4,10 @@ import { format } from "date-fns";
 import { Container, Wrapper } from "../styles/layout.style";
 import { ToggleButton } from "../styles/button.style";
 import Calendar from "../components/calendar/Calendar";
+import { useNavigate } from "react-router-dom";
 
 const Dates: React.FC = () => {
+  const navigate = useNavigate();
   const [selectedDates, setSelectedDates] = useState<Date[]>([]);
   const currentDate = new Date();
 
@@ -14,6 +16,11 @@ const Dates: React.FC = () => {
       if (prev.length === 0 || prev.length === 2) return [date];
       return [...prev, date].sort((a, b) => a.getTime() - b.getTime());
     });
+  };
+
+  const handleSelectDates = () => {
+    // 여행 일정 post 요청
+    navigate("/travel_plans");
   };
 
   const startDate = selectedDates[0];
@@ -34,9 +41,13 @@ const Dates: React.FC = () => {
           />
         </S.DatesArea>
         <S.DatesFooter>
-          <ToggleButton disabled={selectedDates.length === 0}>
+          <ToggleButton
+            onClick={handleSelectDates}
+            disabled={selectedDates.length === 0}
+          >
             {selectedDates.length > 0
-              ? `${format(startDate, "yy.MM.dd")} ~ ${format(endDate, "MM.dd")} / 선택 완료` : "일정을 선택해주세요"}
+              ? `${format(startDate, "yy.MM.dd")} ~ ${format(endDate, "MM.dd")} / 선택 완료`
+              : "일정을 선택해주세요"}
           </ToggleButton>
         </S.DatesFooter>
       </Wrapper>

--- a/Front/src/pages/Dates.tsx
+++ b/Front/src/pages/Dates.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import * as S from "../styles/dates.style";
+import { Container, Wrapper } from "../styles/layout.style";
+import { ToggleButton } from "../styles/button.style";
+
+const Dates: React.FC = () => {
+  const [selectedDates, setSelectedDates] = useState([]);
+  const handleSelectedDates = () => {};
+
+  return (
+    <Container>
+      <Wrapper>
+        <S.DatesHeader>
+          <S.Title>여행 일정 등록</S.Title>
+          <div>각 날짜별 계획하신 여행 일정을 안내해 드립니다.</div>
+        </S.DatesHeader>
+        <S.DatesArea></S.DatesArea>
+        <S.DatesFooter>
+          <ToggleButton
+            onClick={handleSelectedDates}
+            disabled={selectedDates.length === 0}
+          >
+            {selectedDates.length > 0 ? "선택 완료" : "일정을 선택해주세요"}
+          </ToggleButton>
+        </S.DatesFooter>
+      </Wrapper>
+    </Container>
+  );
+};
+
+export default Dates;

--- a/Front/src/pages/Dates.tsx
+++ b/Front/src/pages/Dates.tsx
@@ -1,11 +1,23 @@
 import React, { useState } from "react";
 import * as S from "../styles/dates.style";
+import { format } from "date-fns";
 import { Container, Wrapper } from "../styles/layout.style";
 import { ToggleButton } from "../styles/button.style";
+import Calendar from "../components/calendar/Calendar";
 
 const Dates: React.FC = () => {
-  const [selectedDates, setSelectedDates] = useState([]);
-  const handleSelectedDates = () => {};
+  const [selectedDates, setSelectedDates] = useState<Date[]>([]);
+  const currentDate = new Date();
+
+  const handleDateClick = (date: Date) => {
+    setSelectedDates((prev) => {
+      if (prev.length === 0 || prev.length === 2) return [date];
+      return [...prev, date].sort((a, b) => a.getTime() - b.getTime());
+    });
+  };
+
+  const startDate = selectedDates[0];
+  const endDate = selectedDates[selectedDates.length - 1];
 
   return (
     <Container>
@@ -14,13 +26,17 @@ const Dates: React.FC = () => {
           <S.Title>여행 일정 등록</S.Title>
           <div>각 날짜별 계획하신 여행 일정을 안내해 드립니다.</div>
         </S.DatesHeader>
-        <S.DatesArea></S.DatesArea>
+        <S.DatesArea>
+          <Calendar
+            currentDate={currentDate}
+            selectedDates={selectedDates}
+            onDateClick={handleDateClick}
+          />
+        </S.DatesArea>
         <S.DatesFooter>
-          <ToggleButton
-            onClick={handleSelectedDates}
-            disabled={selectedDates.length === 0}
-          >
-            {selectedDates.length > 0 ? "선택 완료" : "일정을 선택해주세요"}
+          <ToggleButton disabled={selectedDates.length === 0}>
+            {selectedDates.length > 0
+              ? `${format(startDate, "yy.MM.dd")} ~ ${format(endDate, "MM.dd")} / 선택 완료` : "일정을 선택해주세요"}
           </ToggleButton>
         </S.DatesFooter>
       </Wrapper>

--- a/Front/src/routes/routes.tsx
+++ b/Front/src/routes/routes.tsx
@@ -3,6 +3,7 @@ import Home from "../pages/Home";
 import Login from "../pages/Login";
 import schedules from "../../data/schedules.json";
 import Cities from "../pages/Cities";
+import Dates from "../pages/Dates";
 
 const routes = createBrowserRouter([
   {
@@ -17,10 +18,10 @@ const routes = createBrowserRouter([
     path: "/cities",
     element: <Cities />,
   },
-  // {
-  //   path: "/calendar",
-  //   element: <Calendar />,
-  // },
+  {
+    path: "/dates",
+    element: <Dates />,
+  },
   // {
   //   path: "/travel_plans",
   //   element: <TravelPlans />,

--- a/Front/src/styles/calendar.style.ts
+++ b/Front/src/styles/calendar.style.ts
@@ -1,0 +1,83 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  height: 75vh;
+  overflow-y: auto;
+  background-color: #fcfcfc;
+  box-shadow: 0px 5px #fcfcfc;
+  padding: 20px;
+`;
+
+export const MonthContainer = styled.div`
+  padding-bottom: 2rem;
+`;
+
+export const MonthHeader = styled.h3`
+  text-align: center;
+  margin: 2rem 0;
+`;
+
+export const WeekDays = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  font-weight: bold;
+  height: 40px;
+`;
+
+export const WeekDay = styled.div`
+  padding: 5px;
+`;
+
+export const DaysGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+`;
+
+export const Day = styled.div<{
+  $isInRange: boolean;
+  $isStartDate: boolean; 
+  $isEndDate: boolean;
+}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 40px;
+  width: 100%;
+  margin: 2px auto;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  color: ${(props) => props.$isStartDate || props.$isEndDate ? "white" : "black"};
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background-color: ${({ $isInRange }) => ($isInRange ? "#E7F0FF" : "unset")};
+    margin-left: ${({ $isStartDate }) => ($isStartDate ? "50%" : "unset")};
+    margin-right: ${({ $isEndDate }) => ($isEndDate ? "50%" : "unset")};
+    z-index: -1;
+    transform: translateY(-50%);
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: -1;
+    ${(props) =>
+      props.$isStartDate || props.$isEndDate
+        ? `
+        width: 40px;
+        height: 40px;
+        background-color: #4E94F8;
+        border-radius: 50%;`
+        : `background-color: transparent;`}
+  }
+`;

--- a/Front/src/styles/calendar.style.ts
+++ b/Front/src/styles/calendar.style.ts
@@ -50,10 +50,10 @@ export const Day = styled.div<{
   position: relative;
   z-index: 1;
   color: ${(props) =>
-    props.$isWeekend
-      ? "#f20014"
-      : props.$isStartDate || props.$isEndDate
-        ? "white"
+    props.$isStartDate || props.$isEndDate
+      ? "white"
+      : props.$isWeekend
+        ? "#f20014"
         : "black"};
 
   &::before {

--- a/Front/src/styles/calendar.style.ts
+++ b/Front/src/styles/calendar.style.ts
@@ -36,8 +36,9 @@ export const DaysGrid = styled.div`
 
 export const Day = styled.div<{
   $isInRange: boolean;
-  $isStartDate: boolean; 
+  $isStartDate: boolean;
   $isEndDate: boolean;
+  $isWeekend: boolean;
 }>`
   display: flex;
   justify-content: center;
@@ -48,7 +49,12 @@ export const Day = styled.div<{
   cursor: pointer;
   position: relative;
   z-index: 1;
-  color: ${(props) => props.$isStartDate || props.$isEndDate ? "white" : "black"};
+  color: ${(props) =>
+    props.$isWeekend
+      ? "#f20014"
+      : props.$isStartDate || props.$isEndDate
+        ? "white"
+        : "black"};
 
   &::before {
     content: "";

--- a/Front/src/styles/dates.style.ts
+++ b/Front/src/styles/dates.style.ts
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import { Footer, Header } from "./layout.style";
+
+export const DatesHeader = styled(Header)`
+  justify-content: space-around;
+  margin: 0;
+  border-bottom: 2px solid #e0e0e0;
+`;
+
+export const DatesFooter = styled(Footer)`
+  justify-content: unset;
+`;
+
+export const Title = styled.h1`
+  margin: 0;
+`;
+
+export const DatesArea = styled.div`
+  height: 80vh;
+  height: 75vh;
+  overflow-y: auto;
+  background-color: #f9f9f9;
+  box-shadow: 0px 5px #f9f9f9;
+`;

--- a/Front/src/styles/dates.style.ts
+++ b/Front/src/styles/dates.style.ts
@@ -4,11 +4,11 @@ import { Footer, Header } from "./layout.style";
 export const DatesHeader = styled(Header)`
   justify-content: space-around;
   margin: 0;
-  border-bottom: 2px solid #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
 `;
 
 export const DatesFooter = styled(Footer)`
-  justify-content: unset;
+  height: 5vh;
 `;
 
 export const Title = styled.h1`
@@ -17,7 +17,6 @@ export const Title = styled.h1`
 
 export const DatesArea = styled.div`
   height: 80vh;
-  height: 75vh;
   overflow-y: auto;
   background-color: #f9f9f9;
   box-shadow: 0px 5px #f9f9f9;

--- a/Front/src/test/components/Calendar.test.tsx
+++ b/Front/src/test/components/Calendar.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { format } from "date-fns";
+import Calendar from "../../components/calendar/Calendar";
+
+describe("Calendar Component", () => {
+  const currentDate = new Date();
+  const mockOnDateClick = vi.fn();
+
+  it("달력이 표시된다", () => {
+    render(
+      <Calendar
+        currentDate={currentDate}
+        selectedDates={[]}
+        onDateClick={mockOnDateClick}
+      />
+    );
+
+    const monthHeader = screen.getByText(format(currentDate, "yyyy년 MM월"));
+    expect(monthHeader).toBeInTheDocument();
+
+    const dayElements = screen.getAllByText("1");
+    fireEvent.click(dayElements[0]);
+  });
+});

--- a/Front/src/test/pages/Dates.test.tsx
+++ b/Front/src/test/pages/Dates.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import Dates from "../../pages/Dates";
+
+vi.mock("react-router-dom", async () => {
+  const actual = (await vi.importActual("react-router-dom")) as object;
+  return {
+    ...actual, // 원본 모듈의 나머지를 그대로 사용
+    useNavigate: () => vi.fn(), // useNavigate만 모킹
+  };
+});
+
+describe("Dates Component", () => {
+  beforeEach(() => {
+    render(
+      <MemoryRouter>
+        <Dates />
+      </MemoryRouter>
+    );
+  });
+
+  it("초기 렌더링 확인", () => {
+    expect(screen.getByText("여행 일정 등록")).toBeInTheDocument();
+    expect(
+      screen.getByText("각 날짜별 계획하신 여행 일정을 안내해 드립니다.")
+    ).toBeInTheDocument();
+
+    const button = screen.getByRole("button");
+    
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent("일정을 선택해주세요");
+  });
+
+  it("날짜 클릭 후 버튼 활성화", () => {
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+
+    const dayElements = screen.getAllByText("1");
+
+    fireEvent.click(dayElements[0]); // 첫 번째 '1'을 클릭
+
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveTextContent("선택 완료");
+  });
+});

--- a/Front/vite.config.ts
+++ b/Front/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     coverage: {
       reporter: ["text", "lcov"],
       reportsDirectory: "coverage",
-      include: ["src/pages/*.{ts,tsx}"],
+      include: ["src/pages/**/*.{ts,tsx}", "src/components/**/*.{ts,tsx}"],
     },
   },
 });


### PR DESCRIPTION
## 🔢 관련 이슈

#4 
#12 

## 🔧 변경 내용

일정 선택 페이지 및 달력 컴포넌트 구현 

## 🖥️ 스크린샷 (선택사항)
<img width="50%" alt="스크린샷 2024-09-29 오후 6 18 34" src="https://github.com/user-attachments/assets/be2fc613-80b5-4d36-952a-41916019f19e"><img width="50%" alt="스크린샷 2024-09-29 오후 6 20 10" src="https://github.com/user-attachments/assets/d50ce9e0-fc2f-4889-8708-f5d423f6669d">

- 하루만 선택도 가능
- 두 날짜 선택 후 다른 날짜 클릭하면 다시 선택되는 형태

## 🔒 이슈 닫기
