### PR TITLE
[Setting] PR 본문에 백쿼트가 있는 경우에 발생하던 오류 수정

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -26,9 +26,10 @@ jobs:
       - name: 관련 이슈 닫기
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # PR 본문에서 이슈 번호 추출
-          ISSUE_NUMBERS=$(echo "${{ github.event.pull_request.body }}" | grep -oE '#[0-9]+' | sed 's/#//g')
+          ISSUE_NUMBERS=$(echo "${PR_BODY}" | grep -oE '#[0-9]+' | sed 's/#//g')
           
           # 이슈 번호가 하나라도 있는지 확인
           if [ -z "$ISSUE_NUMBERS" ]; then


### PR DESCRIPTION
## 🔢 관련 이슈

[#20 ](https://github.com/Masidao/sip-of-travel/issues/20#issuecomment-2413039876)

## 🔧 변경 내용

https://github.com/orgs/community/discussions/56059 을 참고해서 문제 발생 원인을 찾았습니다.

${{ github.event.pull_request.body }} 를 쉘명령에서 직접 사용하는 것이 아니라 환경변수에 넣어 사용하도록 변경했습니다. 

## 🖥️ 스크린샷 (선택사항)



## 🔒 이슈 닫기

close #20 
